### PR TITLE
Ajustes para publicação no serviço ECS

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+
+# valores usados para o deploy
+PLATFORM=linux/arm64
+PYTHON_VERSION=3-slim
+ECR_REGION=sa-east-1
+ECR_URI=279634266618.dkr.ecr.sa-east-1.amazonaws.com
+ECR_REPO_BASE=comissao-laudos
+TAGS="python-${PYTHON_VERSION} latest"
+COMPOSE_BAKE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
+ARG PYTHON_VERSION=latest
+
 # Use a imagem base do Python
-FROM python:3.11.4
+FROM python:${PYTHON_VERSION}
 
 # Defina o diretório de trabalho
 WORKDIR /app

--- a/aws/taskdefs/laudos-ocr.json
+++ b/aws/taskdefs/laudos-ocr.json
@@ -25,7 +25,7 @@
                 "logDriver": "awslogs",
                 "options": {
                     "awslogs-create-group": "true",
-                    "awslogs-group": "/utfpr/ecs/comissao-laudos",
+                    "awslogs-group": "/utfpr/ecs/comissao-laudos-ct-ocr",
                     "awslogs-region": "sa-east-1",
                     "awslogs-stream-prefix": "ecs"
                 },

--- a/aws/taskdefs/laudos-ocr.json
+++ b/aws/taskdefs/laudos-ocr.json
@@ -1,0 +1,58 @@
+{
+    "family": "comissao-laudos-ct-ocr",
+    "containerDefinitions": [
+        {
+            "name": "comissao-laudos-ocr",
+            "image": "279634266618.dkr.ecr.sa-east-1.amazonaws.com/comissao-laudos/ocr:latest",
+            "cpu": 128,
+            "memory": 1024,
+            "memoryReservation": 512,
+            "portMappings": [
+                {
+                    "name": "comissao-laudos-ocr-8000-tcp",
+                    "containerPort": 8000,
+                    "hostPort": 0,
+                    "protocol": "tcp",
+                    "appProtocol": "http"
+                }
+            ],
+            "essential": true,
+            "environment": [],
+            "mountPoints": [],
+            "volumesFrom": [],
+            "secrets": [],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-create-group": "true",
+                    "awslogs-group": "/utfpr/ecs/comissao-laudos",
+                    "awslogs-region": "sa-east-1",
+                    "awslogs-stream-prefix": "ecs"
+                },
+                "secretOptions": []
+            },
+            "systemControls": []
+        }
+    ],
+    "taskRoleArn": "arn:aws:iam::279634266618:role/ecsTaskExecutionRole",
+    "executionRoleArn": "arn:aws:iam::279634266618:role/ecsTaskExecutionRole",
+    "networkMode": "bridge",
+    "volumes": [],
+    "requiresCompatibilities": [
+        "EC2"
+    ],
+    "runtimePlatform": {
+        "cpuArchitecture": "ARM64",
+        "operatingSystemFamily": "LINUX"
+    },
+    "tags": [
+        {
+            "key": "utfpr-depto",
+            "value": "DAELN-CT"
+        },
+        {
+            "key": "utfpr-usuario",
+            "value": "simonecrocetti"
+        }
+    ]
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  laudos-ocr:
+    container_name: laudos-ocr
+    image: "${ECR_REPO_BASE}/${COMPOSE_PROJECT_NAME}:python-${PYTHON_VERSION}"
+    platform: ${PLATFORM}
+    build: 
+      context: .
+      platforms:
+        - linux/arm64
+      args:
+        PLATFORM: ${PLATFORM}
+        PROJECT: ${COMPOSE_PROJECT_NAME}
+        PYTHON_VERSION: ${PYTHON_VERSION}
+    ports:
+      - "8088:8000"
+    env_file:
+      - path: env/${COMPOSE_PROJECT_NAME}.env
+        required: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Carrega a imagem no ECR
+# A imagem preferencial usada no ECS será aquela com tag latest
+
+PROJECT=$1
+
+if [ -z ${PROJECT} ]; then
+    echo "Uso: deploy.sh <nome_do_projeto>"
+    echo "Erro: Nome do projeto não informado"
+    exit 1
+fi
+
+PROJECT_ENV=env/${PROJECT}.env
+
+if [ ! -r ${PROJECT_ENV} ]; then
+    echo "Erro: Arquivo ${PROJECT_ENV} não existe ou não é legível"
+    exit 2
+fi
+
+source .env
+source ${PROJECT_ENV}
+
+export ECR_REPO=${ECR_REPO_BASE}/${PROJECT}
+ECR_REPO_URI=${ECR_URI}/${ECR_REPO}
+
+# algumas variáveis de ambiente precisam ser passadas ao compose
+export PYTHON_VERSION
+docker compose -p ${PROJECT} build
+
+# aplica os tags à imagem
+for t in $TAGS; do
+    docker tag ${ECR_REPO}:python-${PYTHON_VERSION} ${ECR_REPO_URI}:${t}
+done
+
+# upload da imagem no ECR
+docker push --all-tags ${ECR_REPO_URI}

--- a/env/ocr.env
+++ b/env/ocr.env
@@ -1,0 +1,1 @@
+# Variáveis de ambiente deste projeto

--- a/ocr_server.py
+++ b/ocr_server.py
@@ -16,6 +16,14 @@ six_digit_pattern = re.compile(r'^\d{6}$')
 # Inicializa o FastAPI
 app = FastAPI()
 
+@app.get("/health")
+async def health_check():
+    """
+    Endpoint de verificação de saúde.
+    Retorna um status 200 OK se o serviço estiver ativo.
+    """
+    return {"status": "OK"}
+
 # Endpoint FastAPI para upload da imagem e retorno do OCR
 @app.post("/")
 async def upload_image(file: UploadFile = File(...)):


### PR DESCRIPTION
Os ajustes para publicação no serviço ECS estão completos. A aplicação responde em:
https://laudos-ocr.ct.utfpr.edu.br

Os procedimentos para deploy são os mesmos já descritos para o repositório BACKEND_LAUDOS exceto pelo deploy e nome do serviço:
`$ ./deploy.sh ocr`
`$ ECS_SERVICE_NAME=comissao-laudos-ct-ocr`

**Este serviço está consumindo uma quantidade excessiva de recursos durante a inicialização e deverá ser otimizado. Em 1/6/2025 o limite de memória será reduzido para, no máximo, 512MB e possivelmente deixará de funcionar caso não seja otimizado.**

Os eventuais ajustes para integração das 3 aplicações é de inteira responsabilidade dos desenvolvedores, uma vez que todos os recursos necessários para tal já foram disponibilizados.